### PR TITLE
coverage for commutator test (for Mul)

### DIFF
--- a/sympy/physics/quantum/tests/test_commutator.py
+++ b/sympy/physics/quantum/tests/test_commutator.py
@@ -23,7 +23,8 @@ def test_commutator_identities():
     assert Comm(A, B) == -Comm(B, A)
     assert Comm(A, B).doit() == A*B - B*A
     assert Comm(A, B*C).expand(commutator=True) == Comm(A, B)*C + B*Comm(A, C)
-    assert Comm(A*B, C).expand(commutator=True) == A*Comm(B, C) + Comm(A, C)*B
+    assert Comm(A*B, C*D).expand(commutator=True) == \
+        A*C*Comm(B, D) + A*Comm(B, C)*D + C*Comm(A, D)*B + Comm(A, C)*D*B
     assert Comm(A + B, C + D).expand(commutator=True) == \
         Comm(A, C) + Comm(A, D) + Comm(B, C) + Comm(B, D)
     assert Comm(A, B + C).expand(commutator=True) == Comm(A, B) + Comm(A, C)


### PR DESCRIPTION
Comm(A_B, C) doesn't test the expansion of the first arg being a Mul
since this is rewritten as -Comm(C, A_B) so the test was modified.
(Mul-first was covered incidentally by the test in commutator_dagger,
but now it is tested more explicitly.)
