### PR TITLE
keep minimal definitions of number attributes

### DIFF
--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -594,11 +594,8 @@ class Float(Number):
 
     # A Float represents many real numbers,
     # both rational and irrational.
-    is_rational = None
-    is_irrational = None
-    is_number = True
-
     is_real = True
+    is_number = True
 
     is_Float = True
 
@@ -2028,10 +2025,7 @@ class Zero(with_metaclass(Singleton, IntegerConstant)):
 
     p = 0
     q = 1
-    is_positive = False
-    is_negative = False
     is_zero = True
-    is_composite = False
     is_number = True
     is_imaginary = True
 
@@ -2245,11 +2239,10 @@ class Infinity(with_metaclass(Singleton, Number)):
     .. [1] http://en.wikipedia.org/wiki/Infinity
     """
 
-    is_commutative = True
     is_positive = True
-    is_complex = False
-    is_number = True
     is_infinite = True
+
+    is_number = True
 
     __slots__ = []
 
@@ -2456,11 +2449,10 @@ class NegativeInfinity(with_metaclass(Singleton, Number)):
     Infinity
     """
 
-    is_commutative = True
-    is_positive = True
-    is_complex = False
-    is_number = True
+    is_negative = True
     is_infinite = True
+
+    is_number = True
 
     __slots__ = []
 
@@ -2705,8 +2697,8 @@ class NaN(with_metaclass(Singleton, Number)):
 
     """
     is_commutative = True
+    
     is_comparable = False
-    is_finite = False
     is_number = True
 
     __slots__ = []
@@ -3188,8 +3180,6 @@ class EulerGamma(with_metaclass(Singleton, NumberSymbol)):
 
     is_real = True
     is_positive = True
-    is_negative = False
-    is_irrational = None
     is_number = True
 
     __slots__ = []
@@ -3244,8 +3234,6 @@ class Catalan(with_metaclass(Singleton, NumberSymbol)):
 
     is_real = True
     is_positive = True
-    is_negative = False
-    is_irrational = None
     is_number = True
 
     __slots__ = []
@@ -3293,13 +3281,8 @@ class ImaginaryUnit(with_metaclass(Singleton, AtomicExpr)):
     .. [1] http://en.wikipedia.org/wiki/Imaginary_unit
     """
 
-    is_commutative = True
     is_imaginary = True
-    is_finite = True
     is_number = True
-    is_algebraic = True
-    is_transcendental = False
-    is_real = False
 
     __slots__ = []
 


### PR DESCRIPTION
Using code to test what is implied by the assumptions -- acquired through the assumptions engine or set by attributes in numbers.py...

```
for n in (S.Catalan, S.EulerGamma, S.Exp1, S.GoldenRatio, 
    S.ImaginaryUnit, oo, -oo, zoo, S.Pi, S.One, S.Half, S.Zero, S.NegativeOne):
  print n, minimal_assumptions(dict(n._assumptions))
```

gives this in this PR

```
Catalan (['complex', 'positive'], [])
EulerGamma (['complex', 'positive'], [])
E (['nonnegative', 'transcendental'], [])
GoldenRatio (['algebraic', 'irrational', 'nonnegative'], [])
I (['imaginary'], [])
oo (['infinite', 'nonnegative'], [])
-oo (['infinite', 'nonnegative'], [])
zoo (['infinite'], [])
pi (['nonnegative', 'transcendental'], [])
1 (['integer'], [])
1/2 (['noninteger', 'nonnegative', 'rational'], [])
0 (['zero'], [])
-1 (['integer', 'nonzero'], [])
```

but this in your PR -- note the None which means that there is no simple way to reconstruct the assumptions other than as they are. I think that means you have left them "over defined" in terms of attributes. 

```
Catalan None
EulerGamma None
E (['nonnegative', 'transcendental'], [])
GoldenRatio (['algebraic', 'irrational', 'nonnegative'], [])
I None
oo (['infinite', 'nonnegative'], [])
-oo (['infinite', 'nonnegative'], [])
zoo (['infinite'], [])
pi (['nonnegative', 'transcendental'], [])
1 (['integer'], [])
1/2 (['noninteger', 'nonnegative', 'rational'], [])
0 (['zero'], [])
-1 (['integer', 'nonzero'], [])
```

Note that 'complex, positive' for Catalan in this PR is just another way to say 'real, positive' -- either way the assumptions dictionary comes out the same. I don't think this is what you want (and that has nothing to do with the changes I made, it is a consequence of the assumptions/facts).

```
>>> Dummy(complex=1, positive=1).assumptions0 ==\
... Dummy(real=1,    positive=1).assumptions0
True
```

Note also the docstring of is_comparable (which is not part of the assumptions system). The function is trying to figure out if foo is something that can be computed to a Number with precision.

```
        """Return True if self can be computed to a real number
        with precision, else False.
```
